### PR TITLE
Rest of Server APIs

### DIFF
--- a/cache_server.cc
+++ b/cache_server.cc
@@ -4,6 +4,8 @@
 #include "cache.hh"
 #include <iostream>
 #include <string>
+#include <cstring>
+#include <stdlib.h>
 
 using namespace crow;
 
@@ -75,17 +77,17 @@ int main(int argc, char *argv[])
 
   CROW_ROUTE(app, "/<string>/<string>")
     .methods("HEAD"_method, "PUT"_method)
-  ([&cache, &size](const crow::request& req, crow::response& res, key_type key, val_type val)
+  ([&cache, &size](const crow::request& req, crow::response& res, key_type key, std::string value)
   {
     if (req.method == "HEAD"_method) {
       set_header(req, res, cache);
     }
 
-    size_type size = strlen(val) +1;
-    cache.set(key, value, size);
+    Cache::val_type pval = value.c_str();
+    size = value.size()+1;
+    cache.set(key, pval, size);
 
     res.end();
-
 
   });
 

--- a/cache_server.cc
+++ b/cache_server.cc
@@ -43,6 +43,18 @@ int main(int argc, char *argv[])
   cache.set("k2", val2, strlen(val2)+1);
 
 
+  CROW_ROUTE(app, "/reset")
+    .methods("HEAD"_method, "POST"_method)
+  ([&cache, &size](const crow::request& req, crow::response& res)
+  {
+    if (req.method == "HEAD"_method) {
+      set_header(req, res, cache);
+    }
+    cache.reset();
+    res.end();
+  });
+
+
   // GET /key
   // test with "curl -X GET http://localhost:8080/{key} --output -"
   CROW_ROUTE(app, "/<string>")
@@ -73,8 +85,6 @@ int main(int argc, char *argv[])
 
 
   // PUT /k/v
-
-
   CROW_ROUTE(app, "/<string>/<string>")
     .methods("HEAD"_method, "PUT"_method)
   ([&cache, &size](const crow::request& req, crow::response& res, key_type key, std::string value)
@@ -89,16 +99,6 @@ int main(int argc, char *argv[])
 
     res.end();
 
-  });
-
-  CROW_ROUTE(app, "/reset")
-    .methods("HEAD"_method, "POST"_method)
-  ([&cache, &size](const crow::request& req, crow::response& res)
-  {
-    if (req.method == "HEAD"_method) {
-      set_header(req, res, cache);
-    }
-    cache.reset();
   });
 
 


### PR DESCRIPTION
@davidatp I fixed the compilation errors. A few of them were typos; the more interesting one was setting the correct data type for `value` in a `PUT/ {key}/{value}` request. All parameters in a Crow request should be C strings for the homework (quoted Eitan), so you should only be using `<string>` for all request parameters. 

I tested the SET request -- it sets the correct k/v pair in the Cache. You can test it by calling a SET request with an arbitrary k/v pair and immediately retrieve the pair with a GET request. You can also try to update an existing k/v pair. 

Any static route should be defined before a parameterized route. That's why I moved the `POST /reset` method before `GET /<string>`, because Crow will try to route the request to `/reset` first before considering any other <string> parameter that follows after `/`.  

I tested both the `POST /reset` and `DELETE` methods -- they seem to be working fine. 

After you finish reviewing the PR, can you merge it? It will merge the code to the `work` branch, and I can fix merge conflicts if there are any.